### PR TITLE
Load list of configured sonar instances in global configuration.

### DIFF
--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/GlobalConfig.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/GlobalConfig.java
@@ -29,6 +29,7 @@ public class GlobalConfig extends GlobalConfiguration {
     }
 
     public List<GlobalConfigDataForSonarInstance> getListOfGlobalConfigData() {
+        load();
         return listOfGlobalConfigData;
     }
 


### PR DESCRIPTION
This is a bugfix.

Description:
When there are sonar instances configured globally and jenkins gets restarted, the configured sonar instances are missing. This bugfix loads the configured sonar instances after a jenkins restart.
