### PR TITLE
[JENKINS-34427] (Security) Removed logging of credentials.

### DIFF
--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/GlobalConfigurationService.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/GlobalConfigurationService.java
@@ -20,7 +20,6 @@ public class GlobalConfigurationService {
     }
 
     protected List<GlobalConfigDataForSonarInstance> instantiateGlobalConfigData(JSONObject json) {
-        LOGGER.info(String.format("JSON in the GlobalConfig: %s", json));
         listOfGlobalConfigInstances = new ArrayList<>();
 
         JSON globalDataConfigs = (JSON) json.opt("listOfGlobalConfigData");
@@ -28,7 +27,6 @@ public class GlobalConfigurationService {
             globalDataConfigs = new JSONArray();
         }
         initGlobalDataConfig(globalDataConfigs);
-        LOGGER.info(String.format("JSON in the GlobalConfig after: %s", json));
         return listOfGlobalConfigInstances;
     }
 


### PR DESCRIPTION
Each time a sonar instance get's configured globally, the old as well as the new credentials (incl. the passwords) get's logged. This is a security issue!

This pull request removes the logging of the credentials.
