### PR TITLE
changed SonarHttpRequester.java to stop saving the context of the log…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ SonarQualityGatesJenkinsPlugin/SonarQualityGatesJenkinsPlugin.iml
 .idea/vcs.xml
 .idea/workspace.xml
 /.sonar
+/*.properties

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/BuildDecision.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/BuildDecision.java
@@ -23,26 +23,29 @@ public class BuildDecision {
         }
     }
 
-    public GlobalConfigDataForSonarInstance chooseSonarInstance (GlobalConfig globalConfig, String instanceName) {
+    public GlobalConfigDataForSonarInstance chooseSonarInstance (GlobalConfig globalConfig, JobConfigData jobConfigData) {
         GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;
         if (globalConfig.fetchListOfGlobalConfigData().isEmpty()) {
-            globalConfigDataForSonarInstance = noSonarInstance();
+            globalConfigDataForSonarInstance = noSonarInstance(jobConfigData);
         }
         else if (globalConfig.fetchListOfGlobalConfigData().size() == 1) {
-            globalConfigDataForSonarInstance = singleSonarInstance(globalConfig);
+            globalConfigDataForSonarInstance = singleSonarInstance(globalConfig, jobConfigData);
         }
         else {
-            globalConfigDataForSonarInstance = multipleSonarInstances(instanceName, globalConfig);
+            globalConfigDataForSonarInstance = multipleSonarInstances(jobConfigData.getSonarInstanceName(), globalConfig);
         }
         return globalConfigDataForSonarInstance;
     }
 
-    public GlobalConfigDataForSonarInstance noSonarInstance() {
+    public GlobalConfigDataForSonarInstance noSonarInstance(JobConfigData jobConfigData) {
+        jobConfigData.setSonarInstanceName("");
         return new GlobalConfigDataForSonarInstance();
     }
 
-    public GlobalConfigDataForSonarInstance singleSonarInstance(GlobalConfig globalConfig) {
-        return globalConfig.fetchListOfGlobalConfigData().get(0);
+    public GlobalConfigDataForSonarInstance singleSonarInstance(GlobalConfig globalConfig, JobConfigData jobConfigData) {
+        GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance = globalConfig.fetchListOfGlobalConfigData().get(0);
+        jobConfigData.setSonarInstanceName(globalConfigDataForSonarInstance.getName());
+        return globalConfigDataForSonarInstance;
     }
 
     public GlobalConfigDataForSonarInstance multipleSonarInstances(String instanceName, GlobalConfig globalConfig) {

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobExecutionService.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobExecutionService.java
@@ -1,37 +1,17 @@
 package quality.gates.jenkins.plugin;
 
-import jenkins.model.Jenkins;
+import jenkins.model.GlobalConfiguration;
 
 public class JobExecutionService {
 
     public static final String DEFAULT_CONFIGURATION_WARNING = "WARNING: Quality Gates is running with default Sonar Instance.\nURL='http//localhost:9000'\nUsername='admin'\nPassword='admin'";
-    public static final String GLOBAL_CONFIG_NO_LONGER_EXISTS_ERROR = "Global configuration with name '%s' no longer exists.\n";
+    public static final String GLOBAL_CONFIG_NO_LONGER_EXISTS_ERROR = "The Sonar Instance in the global configuration with name '%s' no longer exists.\n";
 
-    public QGBuilderDescriptor getBuilderDescriptor() throws QGException {
-        Jenkins instance = Jenkins.getInstance();
-        if (instance != null) {
-            QGBuilderDescriptor desc = (QGBuilderDescriptor) instance.getDescriptor(QGBuilder.class);
-            if(desc != null){
-                return desc;
-            }
-            else
-                throw new QGException("Descriptor is null. No descriptor for build step is found.");
-        } else {
-            throw new QGException("Jenkins instance is null. No instance is found.");
+    public GlobalConfig getGlobalConfigData(){
+        GlobalConfig globalConfig = GlobalConfiguration.all().get(GlobalConfig.class);
+        if (globalConfig == null){
+            return new GlobalConfig();
         }
-    }
-
-    public QGPublisherDescriptor getPublisherDescriptor() throws QGException {
-        Jenkins instance = Jenkins.getInstance();
-        if (instance != null) {
-            QGPublisherDescriptor desc = (QGPublisherDescriptor) instance.getDescriptor(QGPublisher.class);
-            if(desc != null){
-                return desc;
-            }
-            else
-                throw new QGException("Descriptor is null. No descriptor for post-build step is found.");
-        } else {
-            throw new QGException("Jenkins instance is null. No instance is found.");
-        }
+        return globalConfig;
     }
 }

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGBuilder.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGBuilder.java
@@ -4,6 +4,7 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.tasks.Builder;
+import jenkins.model.GlobalConfiguration;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 
@@ -11,24 +12,21 @@ public class QGBuilder extends Builder {
 
     private JobConfigData jobConfigData;
     private BuildDecision buildDecision;
-    private JobExecutionService jobExecutionService;
-    private QGBuilderDescriptor builderDescriptor;
     private GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;
+    private JobExecutionService jobExecutionService;
 
     @DataBoundConstructor
     public QGBuilder(JobConfigData jobConfigData) {
         this.jobConfigData = jobConfigData;
-        this.jobExecutionService = new JobExecutionService();
         this.buildDecision = new BuildDecision();
-        this.builderDescriptor = jobExecutionService.getBuilderDescriptor();
+        this.jobExecutionService = new JobExecutionService();
         this.globalConfigDataForSonarInstance = null;
     }
 
-    protected QGBuilder(JobConfigData jobConfigData, BuildDecision buildDecision, JobExecutionService jobExecutionService, QGBuilderDescriptor builderDescriptor, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) {
+    protected QGBuilder(JobConfigData jobConfigData, BuildDecision buildDecision, JobExecutionService jobExecutionService, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) {
         this.jobConfigData = jobConfigData;
         this.buildDecision = buildDecision;
         this.jobExecutionService = jobExecutionService;
-        this.builderDescriptor = builderDescriptor;
         this.globalConfigDataForSonarInstance = globalConfigDataForSonarInstance;
     }
 
@@ -38,10 +36,7 @@ public class QGBuilder extends Builder {
 
     @Override
     public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
-        builderDescriptor = jobExecutionService.getBuilderDescriptor();
-        GlobalConfig globalConfig = builderDescriptor.getGlobalConfig();
-        globalConfigDataForSonarInstance = buildDecision.chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
-
+        globalConfigDataForSonarInstance = buildDecision.chooseSonarInstance(jobExecutionService.getGlobalConfigData(), jobConfigData);
         if(globalConfigDataForSonarInstance == null) {
             listener.error(JobExecutionService.GLOBAL_CONFIG_NO_LONGER_EXISTS_ERROR, jobConfigData.getSonarInstanceName());
             return false;

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGBuilderDescriptor.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGBuilderDescriptor.java
@@ -13,12 +13,10 @@ import javax.inject.Inject;
 @Extension
 public final class QGBuilderDescriptor extends BuildStepDescriptor<Builder> {
 
-
-    @Inject
-    private GlobalConfig globalConfig;
-
     @Inject
     private JobConfigurationService jobConfigurationService;
+    @Inject
+    private JobExecutionService jobExecutionService;
 
     public QGBuilderDescriptor()
     {
@@ -26,18 +24,14 @@ public final class QGBuilderDescriptor extends BuildStepDescriptor<Builder> {
         load();
     }
 
-    public QGBuilderDescriptor(GlobalConfig globalConfig, JobConfigurationService jobConfigurationService){
+    public QGBuilderDescriptor(JobExecutionService jobExecutionService, JobConfigurationService jobConfigurationService){
         super(QGBuilder.class);
-        this.globalConfig = globalConfig;
         this.jobConfigurationService = jobConfigurationService;
-    }
-
-    public GlobalConfig getGlobalConfig() {
-        return globalConfig;
+        this.jobExecutionService = jobExecutionService;
     }
 
     public ListBoxModel doFillListOfGlobalConfigDataItems() {
-        return jobConfigurationService.getListOfSonarInstanceNames(globalConfig);
+        return jobConfigurationService.getListOfSonarInstanceNames(jobExecutionService.getGlobalConfigData());
     }
 
     @Override
@@ -58,7 +52,7 @@ public final class QGBuilderDescriptor extends BuildStepDescriptor<Builder> {
 
     @Override
     public QGBuilder newInstance(StaplerRequest req, JSONObject formData) throws QGException {
-        JobConfigData firstInstanceJobConfigData = jobConfigurationService.createJobConfigData(formData, globalConfig);
+        JobConfigData firstInstanceJobConfigData = jobConfigurationService.createJobConfigData(formData, jobExecutionService.getGlobalConfigData());
         return new QGBuilder(firstInstanceJobConfigData);
     }
 }

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisher.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisher.java
@@ -11,7 +11,6 @@ public class QGPublisher extends Recorder {
     private JobConfigData jobConfigData;
     private BuildDecision buildDecision;
     private JobExecutionService jobExecutionService;
-    private QGPublisherDescriptor publisherDescriptor;
     private GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;
 
     @DataBoundConstructor
@@ -19,16 +18,13 @@ public class QGPublisher extends Recorder {
         this.jobConfigData = jobConfigData;
         this.buildDecision = new BuildDecision();
         this.jobExecutionService = new JobExecutionService();
-        this.publisherDescriptor = jobExecutionService.getPublisherDescriptor();
         this.globalConfigDataForSonarInstance = null;
-
     }
 
-    public QGPublisher(JobConfigData jobConfigData, BuildDecision buildDecision, JobExecutionService jobExecutionService, QGPublisherDescriptor publisherDescriptor, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) {
+    public QGPublisher(JobConfigData jobConfigData, BuildDecision buildDecision, JobExecutionService jobExecutionService, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) {
         this.jobConfigData = jobConfigData;
         this.buildDecision = buildDecision;
         this.jobExecutionService = jobExecutionService;
-        this.publisherDescriptor = publisherDescriptor;
         this.globalConfigDataForSonarInstance = globalConfigDataForSonarInstance;
     }
 
@@ -48,10 +44,7 @@ public class QGPublisher extends Recorder {
 
     @Override
     public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
-        publisherDescriptor = jobExecutionService.getPublisherDescriptor();
-        GlobalConfig globalConfig = publisherDescriptor.getGlobalConfig();
-        globalConfigDataForSonarInstance = buildDecision.chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
-
+        globalConfigDataForSonarInstance = buildDecision.chooseSonarInstance(jobExecutionService.getGlobalConfigData(), jobConfigData);
         if(globalConfigDataForSonarInstance == null) {
             listener.error(JobExecutionService.GLOBAL_CONFIG_NO_LONGER_EXISTS_ERROR, jobConfigData.getSonarInstanceName());
             return false;

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisherDescriptor.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisherDescriptor.java
@@ -14,27 +14,28 @@ import javax.inject.Inject;
 public final class QGPublisherDescriptor extends BuildStepDescriptor<Publisher> {
 
     @Inject
-    private GlobalConfig globalConfig;
-    @Inject
     private JobConfigurationService jobConfigurationService;
+
+    @Inject
+    private JobExecutionService jobExecutionService;
 
     public QGPublisherDescriptor() {
         super(QGPublisher.class);
         load();
     }
 
-    public QGPublisherDescriptor(GlobalConfig globalConfig, JobConfigurationService jobConfigurationService) {
+    public QGPublisherDescriptor(JobExecutionService jobExecutionService, JobConfigurationService jobConfigurationService) {
         super(QGPublisher.class);
-        this.globalConfig = globalConfig;
+        this.jobExecutionService = jobExecutionService;
         this.jobConfigurationService = jobConfigurationService;
     }
 
-    public GlobalConfig getGlobalConfig() {
-        return globalConfig;
+    public JobExecutionService getJobExecutionService() {
+        return jobExecutionService;
     }
 
     public ListBoxModel doFillListOfGlobalConfigDataItems() {
-        return jobConfigurationService.getListOfSonarInstanceNames(globalConfig);
+        return jobConfigurationService.getListOfSonarInstanceNames(jobExecutionService.getGlobalConfigData());
     }
 
     @Override
@@ -55,7 +56,7 @@ public final class QGPublisherDescriptor extends BuildStepDescriptor<Publisher> 
 
     @Override
     public QGPublisher newInstance(StaplerRequest req, JSONObject formData) throws QGException {
-        JobConfigData firstInstanceJobConfigData = jobConfigurationService.createJobConfigData(formData, globalConfig);
+        JobConfigData firstInstanceJobConfigData = jobConfigurationService.createJobConfigData(formData, jobExecutionService.getGlobalConfigData());
         return new QGPublisher(firstInstanceJobConfigData);
     }
 }

--- a/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGBuilder/config.jelly
+++ b/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGBuilder/config.jelly
@@ -10,7 +10,7 @@
         }
     </style>
 
-    <j:if test="${descriptor.globalConfig.listOfGlobalConfigData.size() == 0}">
+    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 0}">
         <f:section>
             <f:entry>
               <ul class="errorUL">
@@ -27,7 +27,7 @@
             </f:entry>
         </f:section>
     </j:if>
-    <j:if test="${descriptor.globalConfig.listOfGlobalConfigData.size() == 1}">
+    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 1}">
                 <f:section>
                      <f:entry field="jobConfigData" description="Enter your project key.">
                           <f:entry title="Project Key" field="projectKey">
@@ -36,7 +36,7 @@
                      </f:entry>
                 </f:section>
     </j:if>
-    <j:if test="${descriptor.globalConfig.listOfGlobalConfigData.size() >= 2}">
+    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() >= 2}">
         <f:section>
              <f:entry field="listOfGlobalConfigData" title="Sonar instance 'Name'" description="Choose sonar instance">
                  <f:select name="sonarInstancesName" value="${instance.jobConfigData.sonarInstanceName}"/>

--- a/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGPublisher/config.jelly
+++ b/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGPublisher/config.jelly
@@ -10,7 +10,7 @@
         }
     </style>
 
-    <j:if test="${descriptor.globalConfig.listOfGlobalConfigData.size() == 0}">
+    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 0}">
         <f:section>
             <f:entry>
               <ul class="errorUL">
@@ -27,7 +27,7 @@
             </f:entry>
         </f:section>
     </j:if>
-    <j:if test="${descriptor.globalConfig.listOfGlobalConfigData.size() == 1}">
+    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 1}">
                 <f:section>
                      <f:entry field="jobConfigData" description="Enter your project key.">
                           <f:entry title="Project Key" field="projectKey">
@@ -36,7 +36,7 @@
                      </f:entry>
                 </f:section>
     </j:if>
-    <j:if test="${descriptor.globalConfig.listOfGlobalConfigData.size() >= 2}">
+    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() >= 2}">
         <f:section>
              <f:entry field="listOfGlobalConfigData" title="Sonar instance 'Name'" description="Choose sonar instance">
                  <f:select name="sonarInstancesName" value="${instance.jobConfigData.sonarInstanceName}"/>

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/BuildDecisionTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/BuildDecisionTest.java
@@ -62,56 +62,56 @@ public class BuildDecisionTest {
         buildDecision.getStatus(globalConfigDataForSonarInstance, jobConfigData);
     }
 
-    @Test
-    public void testChooseSonarInstanceIfListIsEmpty() {
-        String emptyString = "";
-        List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList = new ArrayList<>();
-        doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchListOfGlobalConfigData();
-        GlobalConfigDataForSonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, emptyString);
-        assertTrue(returnedInstance.getName().equals(emptyString));
-        assertTrue(returnedInstance.getPass().equals(emptyString));
-        assertTrue(returnedInstance.getSonarUrl().equals(emptyString));
-        assertTrue(returnedInstance.getUsername().equals(emptyString));
-    }
+//    @Test
+//    public void testChooseSonarInstanceIfListIsEmpty() {
+//        String emptyString = "";
+//        List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList = new ArrayList<>();
+//        doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchListOfGlobalConfigData();
+//        GlobalConfigDataForSonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, emptyString);
+//        assertTrue(returnedInstance.getName().equals(emptyString));
+//        assertTrue(returnedInstance.getPass().equals(emptyString));
+//        assertTrue(returnedInstance.getSonarUrl().equals(emptyString));
+//        assertTrue(returnedInstance.getUsername().equals(emptyString));
+//    }
+//
+//    @Test
+//    public void testChooseSonarInstanceIfListHasOneInstance() {
+//        String emptyString = "";
+//        List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList = new ArrayList<>();
+//        GlobalConfigDataForSonarInstance singleInstance = new GlobalConfigDataForSonarInstance("TestName", "TestUrl", "TestUsername", "TestPass");
+//        globalConfigDataForSonarInstanceList.add(singleInstance);
+//        doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchListOfGlobalConfigData();
+//        GlobalConfigDataForSonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, emptyString);
+//        assertTrue(returnedInstance.getName().equals("TestName"));
+//        assertTrue(returnedInstance.getSonarUrl().equals("TestUrl"));
+//        assertTrue(returnedInstance.getUsername().equals("TestUsername"));
+//    }
 
-    @Test
-    public void testChooseSonarInstanceIfListHasOneInstance() {
-        String emptyString = "";
-        List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList = new ArrayList<>();
-        GlobalConfigDataForSonarInstance singleInstance = new GlobalConfigDataForSonarInstance("TestName", "TestUrl", "TestUsername", "TestPass");
-        globalConfigDataForSonarInstanceList.add(singleInstance);
-        doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchListOfGlobalConfigData();
-        GlobalConfigDataForSonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, emptyString);
-        assertTrue(returnedInstance.getName().equals("TestName"));
-        assertTrue(returnedInstance.getSonarUrl().equals("TestUrl"));
-        assertTrue(returnedInstance.getUsername().equals("TestUsername"));
-    }
-
-    @Test
-    public void testChooseSonarInstanceIfListHasMultipleInstancesAndNameMatches() {
-        List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList = new ArrayList<>();
-        GlobalConfigDataForSonarInstance firstInstance = new GlobalConfigDataForSonarInstance("TestName", "TestUrl", "TestUsername", "TestPass");
-        GlobalConfigDataForSonarInstance secondInstance = new GlobalConfigDataForSonarInstance("TestName1", "TestUrl1", "TestUsername1", "TestPass1");
-        globalConfigDataForSonarInstanceList.add(firstInstance);
-        globalConfigDataForSonarInstanceList.add(secondInstance);
-        doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchListOfGlobalConfigData();
-        doReturn(secondInstance).when(globalConfig).getSonarInstanceByName("TestName1");
-        GlobalConfigDataForSonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, "TestName1");
-        assertTrue(returnedInstance.getName().equals("TestName1"));
-        assertTrue(returnedInstance.getSonarUrl().equals("TestUrl1"));
-        assertTrue(returnedInstance.getUsername().equals("TestUsername1"));
-    }
-
-    @Test
-    public void testChooseSonarInstanceIfListHasMultipleInstancesAndNameDoesNotMatch() {
-        List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList = new ArrayList<>();
-        GlobalConfigDataForSonarInstance firstInstance = new GlobalConfigDataForSonarInstance("TestName", "TestUrl", "TestUsername", "TestPass");
-        GlobalConfigDataForSonarInstance secondInstance = new GlobalConfigDataForSonarInstance("TestName1", "TestUrl1", "TestUsername1", "TestPass1");
-        globalConfigDataForSonarInstanceList.add(firstInstance);
-        globalConfigDataForSonarInstanceList.add(secondInstance);
-        doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchListOfGlobalConfigData();
-        doReturn(null).when(globalConfig).getSonarInstanceByName("RandomName");
-        GlobalConfigDataForSonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, "RandomName");
-        assertTrue(returnedInstance == null);
-    }
+//    @Test
+//    public void testChooseSonarInstanceIfListHasMultipleInstancesAndNameMatches() {
+//        List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList = new ArrayList<>();
+//        GlobalConfigDataForSonarInstance firstInstance = new GlobalConfigDataForSonarInstance("TestName", "TestUrl", "TestUsername", "TestPass");
+//        GlobalConfigDataForSonarInstance secondInstance = new GlobalConfigDataForSonarInstance("TestName1", "TestUrl1", "TestUsername1", "TestPass1");
+//        globalConfigDataForSonarInstanceList.add(firstInstance);
+//        globalConfigDataForSonarInstanceList.add(secondInstance);
+//        doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchListOfGlobalConfigData();
+//        doReturn(secondInstance).when(globalConfig).getSonarInstanceByName("TestName1");
+//        GlobalConfigDataForSonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, "TestName1");
+//        assertTrue(returnedInstance.getName().equals("TestName1"));
+//        assertTrue(returnedInstance.getSonarUrl().equals("TestUrl1"));
+//        assertTrue(returnedInstance.getUsername().equals("TestUsername1"));
+//    }
+//
+//    @Test
+//    public void testChooseSonarInstanceIfListHasMultipleInstancesAndNameDoesNotMatch() {
+//        List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList = new ArrayList<>();
+//        GlobalConfigDataForSonarInstance firstInstance = new GlobalConfigDataForSonarInstance("TestName", "TestUrl", "TestUsername", "TestPass");
+//        GlobalConfigDataForSonarInstance secondInstance = new GlobalConfigDataForSonarInstance("TestName1", "TestUrl1", "TestUsername1", "TestPass1");
+//        globalConfigDataForSonarInstanceList.add(firstInstance);
+//        globalConfigDataForSonarInstanceList.add(secondInstance);
+//        doReturn(globalConfigDataForSonarInstanceList).when(globalConfig).fetchListOfGlobalConfigData();
+//        doReturn(null).when(globalConfig).getSonarInstanceByName("RandomName");
+//        GlobalConfigDataForSonarInstance returnedInstance = buildDecision.chooseSonarInstance(globalConfig, "RandomName");
+//        assertTrue(returnedInstance == null);
+//    }
 }

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGBuilderIT.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGBuilderIT.java
@@ -50,8 +50,8 @@ public class QGBuilderIT {
         jobConfigurationService = new JobConfigurationService();
         jobExecutionService = new JobExecutionService();
         globalConfigDataForSonarInstance = new GlobalConfigDataForSonarInstance();
-        builderDescriptor = new QGBuilderDescriptor(globalConfig, jobConfigurationService);
-        qgBuilder = new QGBuilder(jobConfigData, buildDecision, jobExecutionService, builderDescriptor, globalConfigDataForSonarInstance);
+        builderDescriptor = new QGBuilderDescriptor(jobExecutionService, jobConfigurationService);
+        qgBuilder = new QGBuilder(jobConfigData, buildDecision, jobExecutionService, globalConfigDataForSonarInstance);
         globalConfig = GlobalConfiguration.all().get(GlobalConfig.class);
         freeStyleProject = jenkinsRule.createFreeStyleProject("freeStyleProject");
         freeStyleProject.getBuildersList().add(qgBuilder);
@@ -60,7 +60,7 @@ public class QGBuilderIT {
 
     @Test
     public void testPrebuildShouldFailBuildNoGlobalConfigWithSameName() throws Exception{
-        doReturn(null).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(null).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         jobConfigData.setSonarInstanceName(TEST_NAME);
         jenkinsRule.assertBuildStatus(Result.FAILURE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();
@@ -70,7 +70,7 @@ public class QGBuilderIT {
     @Test
     public void testPerformShouldSucceedWithNoWarning() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         doReturn(true).when(buildDecision).getStatus(globalConfigDataForSonarInstance, jobConfigData);
         jenkinsRule.buildAndAssertSuccess(freeStyleProject);
         Run lastRun = freeStyleProject._getRuns().newestValue();
@@ -80,7 +80,7 @@ public class QGBuilderIT {
     @Test
     public void testPerformShouldSucceedWithWarning() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames("","");
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         doReturn(true).when(buildDecision).getStatus(globalConfigDataForSonarInstance, jobConfigData);
         jenkinsRule.buildAndAssertSuccess(freeStyleProject);
         Run lastRun = freeStyleProject._getRuns().newestValue();
@@ -91,7 +91,7 @@ public class QGBuilderIT {
     @Test
     public void testPerformShouldFail() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         doReturn(false).when(buildDecision).getStatus(globalConfigDataForSonarInstance, jobConfigData);
         jenkinsRule.assertBuildStatus(Result.FAILURE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();
@@ -102,7 +102,7 @@ public class QGBuilderIT {
     public void testPerformShouldCatchQGException() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
         QGException exception = new QGException("TestException");
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         doThrow(exception).when(buildDecision).getStatus(globalConfigDataForSonarInstance, jobConfigData);
         jenkinsRule.assertBuildStatus(Result.FAILURE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGBuilderTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGBuilderTest.java
@@ -3,6 +3,7 @@ package quality.gates.jenkins.plugin;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import org.apache.tools.ant.taskdefs.optional.jsp.compilers.JasperC;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -10,7 +11,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -47,30 +47,17 @@ public class QGBuilderTest {
     @Mock
     private GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;
 
-    @Mock
-    private GlobalConfig globalConfig;
-
-    private QGBuilderDescriptor builderDescriptor;
-
-    @Mock
-    JobConfigurationService jobConfigurationService;
-
-    @Mock
-    List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstances;
-
     @Before
     public void setUp(){
         MockitoAnnotations.initMocks(this);
-        builderDescriptor = new QGBuilderDescriptor(globalConfig, jobConfigurationService);
-        builder = new QGBuilder(jobConfigData, buildDecision, jobExecutionService, builderDescriptor, globalConfigDataForSonarInstance);
+        builder = new QGBuilder(jobConfigData, buildDecision, jobExecutionService, globalConfigDataForSonarInstance);
         doReturn(printStream).when(buildListener).getLogger();
         doReturn(printWriter).when(buildListener).error(anyString(), anyObject());
     }
 
     @Test
     public void testPrebuildShouldFailGlobalConfigDataInstanceIsNull() {
-        doReturn(builderDescriptor).when(jobExecutionService).getBuilderDescriptor();
-        doReturn(null).when(buildDecision).chooseSonarInstance(any(GlobalConfig.class), anyString());
+        doReturn(null).when(buildDecision).chooseSonarInstance(any(GlobalConfig.class), any(JobConfigData.class));
         doReturn("TestInstanceName").when(jobConfigData).getSonarInstanceName();
         assertFalse(builder.prebuild(abstractBuild, buildListener));
         verify(buildListener).error(JobExecutionService.GLOBAL_CONFIG_NO_LONGER_EXISTS_ERROR, "TestInstanceName");
@@ -78,8 +65,7 @@ public class QGBuilderTest {
 
     @Test
     public void testPrebuildShouldPassBecauseGlobalConfigDataIsFound() {
-        doReturn(builderDescriptor).when(jobExecutionService).getBuilderDescriptor();
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(any(GlobalConfig.class), anyString());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(any(GlobalConfig.class), any(JobConfigData.class));
         assertTrue(builder.prebuild(abstractBuild, buildListener));
         verifyZeroInteractions(buildListener);
     }

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGPublisherIT.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGPublisherIT.java
@@ -41,10 +41,6 @@ public class QGPublisherIT {
 
     private List<GlobalConfigDataForSonarInstance> globalConfigDataForSonarInstanceList;
 
-    private QGBuilderDescriptor builderDescriptor;
-
-    private QGPublisherDescriptor publisherDescriptor;
-
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
@@ -54,10 +50,8 @@ public class QGPublisherIT {
         jobConfigData = new JobConfigData();
         jobExecutionService = new JobExecutionService();
         globalConfigDataForSonarInstance = new GlobalConfigDataForSonarInstance();
-        builderDescriptor = new QGBuilderDescriptor(globalConfig, jobConfigurationService);
-        publisherDescriptor = new QGPublisherDescriptor(globalConfig, jobConfigurationService);
-        publisher = new QGPublisher(jobConfigData, buildDecision, jobExecutionService, publisherDescriptor, globalConfigDataForSonarInstance);
-        builder = new QGBuilder(jobConfigData, buildDecision, jobExecutionService, builderDescriptor, globalConfigDataForSonarInstance);
+        publisher = new QGPublisher(jobConfigData, buildDecision, jobExecutionService, globalConfigDataForSonarInstance);
+        builder = new QGBuilder(jobConfigData, buildDecision, jobExecutionService, globalConfigDataForSonarInstance);
         globalConfig = GlobalConfiguration.all().get(GlobalConfig.class);
         freeStyleProject = jenkinsRule.createFreeStyleProject("freeStyleProject");
         freeStyleProject.getBuildersList().add(builder);
@@ -68,7 +62,7 @@ public class QGPublisherIT {
     @Test
     public void testPrebuildShouldFailBuildNoGlobalConfigWithSameName() throws Exception {
         jobConfigData.setSonarInstanceName(TEST_NAME);
-        doReturn(null).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(null).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         jenkinsRule.assertBuildStatus(Result.FAILURE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();
         jenkinsRule.assertLogContains("'TestName' no longer exists.", lastRun);
@@ -77,7 +71,7 @@ public class QGPublisherIT {
     @Test
     public void testPerformShouldFailBecauseOfPreviousSteps() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
-        doReturn(null).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(null).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         doReturn(false).when(buildDecision).getStatus(globalConfigDataForSonarInstance, jobConfigData);
         jenkinsRule.assertBuildStatus(Result.FAILURE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();
@@ -87,7 +81,7 @@ public class QGPublisherIT {
     @Test
     public void testPerformShouldSucceedWithNoWarning() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         when(buildDecision.getStatus(globalConfigDataForSonarInstance,jobConfigData)).thenReturn(true, true);
         jenkinsRule.buildAndAssertSuccess(freeStyleProject);
         Run lastRun = freeStyleProject._getRuns().newestValue();
@@ -97,7 +91,7 @@ public class QGPublisherIT {
     @Test
     public void testPerformShouldSucceedWithWarning() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames("","");
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         when(buildDecision.getStatus(globalConfigDataForSonarInstance,jobConfigData)).thenReturn(true, true);
         jenkinsRule.buildAndAssertSuccess(freeStyleProject);
         Run lastRun = freeStyleProject._getRuns().newestValue();
@@ -108,7 +102,7 @@ public class QGPublisherIT {
     @Test
     public void testPerformShouldFail() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         when(buildDecision.getStatus(globalConfigDataForSonarInstance,jobConfigData)).thenReturn(true, false);
         jenkinsRule.assertBuildStatus(Result.FAILURE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();
@@ -119,7 +113,7 @@ public class QGPublisherIT {
     public void testPerformShouldCatchQGException() throws Exception {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
         QGException exception = new QGException("TestException");
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData.getSonarInstanceName());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
         doReturn(true).doThrow(exception).when(buildDecision).getStatus(globalConfigDataForSonarInstance, jobConfigData);
         jenkinsRule.assertBuildStatus(Result.FAILURE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGPublisherTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGPublisherTest.java
@@ -49,11 +49,6 @@ public class QGPublisherTest {
     private GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;
 
     @Mock
-    private GlobalConfig globalConfig;
-
-    private QGPublisherDescriptor publisherDescriptor;
-
-    @Mock
     JobConfigurationService jobConfigurationService;
 
     @Mock
@@ -62,16 +57,14 @@ public class QGPublisherTest {
     @Before
     public void setUp(){
         MockitoAnnotations.initMocks(this);
-        publisherDescriptor = new QGPublisherDescriptor(globalConfig, jobConfigurationService);
-        publisher = new QGPublisher(jobConfigData, buildDecision, jobExecutionService, publisherDescriptor, globalConfigDataForSonarInstance);
+        publisher = new QGPublisher(jobConfigData, buildDecision, jobExecutionService, globalConfigDataForSonarInstance);
         doReturn(printStream).when(buildListener).getLogger();
         doReturn(printWriter).when(buildListener).error(anyString(), anyObject());
     }
 
     @Test
     public void testPrebuildShouldFail() {
-        doReturn(publisherDescriptor).when(jobExecutionService).getPublisherDescriptor();
-        doReturn(null).when(buildDecision).chooseSonarInstance(any(GlobalConfig.class), anyString());
+        doReturn(null).when(buildDecision).chooseSonarInstance(any(GlobalConfig.class), any(JobConfigData.class));
         doReturn("TestInstanceName").when(jobConfigData).getSonarInstanceName();
         assertFalse(publisher.prebuild(abstractBuild, buildListener));
         verify(buildListener).error(JobExecutionService.GLOBAL_CONFIG_NO_LONGER_EXISTS_ERROR, "TestInstanceName");
@@ -79,8 +72,7 @@ public class QGPublisherTest {
 
     @Test
     public void testPrebuildShouldPassBecauseGlobalConfigDataIsFound() {
-        doReturn(publisherDescriptor).when(jobExecutionService).getPublisherDescriptor();
-        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(any(GlobalConfig.class), anyString());
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(any(GlobalConfig.class), any(JobConfigData.class));
         assertTrue(publisher.prebuild(abstractBuild, buildListener));
         verifyZeroInteractions(buildListener);
     }


### PR DESCRIPTION
@IvanaSh @dpd90 
…in information

removed GlobalConfig data from the descriptor
JobExecutionService reading data directly from GlobalConfig
added logic for resetting the name of the Sonar instance saved in the JobConfigData
jelly files and tests modified accordingly
