### PR TITLE
Adding support to allow warning/orange sonar status builds to pass (optional)

### DIFF
--- a/QualityGatesPlugin/pom.xml
+++ b/QualityGatesPlugin/pom.xml
@@ -35,7 +35,7 @@
     <artifactId>quality-gates</artifactId>
     <name>Quality Gates Plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Quality+Gates+Plugin</url>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.6-SNAPSHOT</version>
     <description>Fails the build whenever the Quality Gates criteria in the Sonar analysis aren't met (the project Quality Gates status is different than "Passed")</description>
     <packaging>hpi</packaging>
 
@@ -184,6 +184,10 @@
         <developer>
             <id>dpd90</id>
             <name>Dimitar Pop-Dimitrov</name>
+        </developer>
+        <developer>
+        	<id>lmpessoa</id>
+        	<name>Leonardo Pessoa</name>
         </developer>
     </developers>
 

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/BuildDecision.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/BuildDecision.java
@@ -9,7 +9,7 @@ import hudson.model.Result;
 
 public class BuildDecision {
 
-    QualityGatesProvider qualityGatesProvider;
+    private QualityGatesProvider qualityGatesProvider;
 
     public BuildDecision() {
         qualityGatesProvider = new QualityGatesProvider();
@@ -31,7 +31,7 @@ public class BuildDecision {
             throw new QGException("Please check your credentials or your Project Key", e);
         }
     }
-    
+
     public GlobalConfigDataForSonarInstance chooseSonarInstance (GlobalConfig globalConfig, JobConfigData jobConfigData) {
         GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;
         if (globalConfig.fetchListOfGlobalConfigData().isEmpty()) {

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/BuildDecision.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/BuildDecision.java
@@ -1,11 +1,15 @@
 package quality.gates.jenkins.plugin;
 
 import quality.gates.sonar.api.QualityGatesProvider;
+import quality.gates.sonar.api.QualityGatesStatus;
+
 import org.json.JSONException;
+
+import hudson.model.Result;
 
 public class BuildDecision {
 
-    private QualityGatesProvider qualityGatesProvider;
+    QualityGatesProvider qualityGatesProvider;
 
     public BuildDecision() {
         qualityGatesProvider = new QualityGatesProvider();
@@ -15,14 +19,19 @@ public class BuildDecision {
         this.qualityGatesProvider = qualityGatesProvider;
     }
 
-    public boolean getStatus(GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance, JobConfigData jobConfigData) throws QGException {
+    public Result getStatus(GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance, JobConfigData jobConfigData) throws QGException {
         try {
-            return qualityGatesProvider.getAPIResultsForQualityGates(jobConfigData, globalConfigDataForSonarInstance).hasStatusGreen();
+            QualityGatesStatus qualityGate = qualityGatesProvider.getAPIResultsForQualityGates(jobConfigData, globalConfigDataForSonarInstance);
+            if (qualityGate == QualityGatesStatus.GREEN)
+            	return Result.SUCCESS;
+            if (jobConfigData.getIgnoreWarnings() && qualityGate == QualityGatesStatus.ORANGE)
+            	return Result.UNSTABLE;
+            return Result.FAILURE;
         } catch (JSONException e) {
             throw new QGException("Please check your credentials or your Project Key", e);
         }
     }
-
+    
     public GlobalConfigDataForSonarInstance chooseSonarInstance (GlobalConfig globalConfig, JobConfigData jobConfigData) {
         GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;
         if (globalConfig.fetchListOfGlobalConfigData().isEmpty()) {

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigData.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigData.java
@@ -4,7 +4,8 @@ public class JobConfigData {
 
     private String projectKey;
     private String sonarInstanceName;
-
+    private boolean ignoreWarnings;
+    
 
     public String getProjectKey() {
         return projectKey;
@@ -21,12 +22,21 @@ public class JobConfigData {
     public void setSonarInstanceName(String sonarInstanceName) {
         this.sonarInstanceName = sonarInstanceName;
     }
+    
+    public boolean getIgnoreWarnings() {
+    	return ignoreWarnings;
+    }
+    
+    public void setIgnoreWarnings(boolean ignoreWarnings) {
+    	this.ignoreWarnings = ignoreWarnings;
+    }
 
     @Override
     public String toString() {
         return "JobConfigData{" +
                 "projectKey='" + projectKey + '\'' +
                 ", sonarInstanceName='" + sonarInstanceName + '\'' +
+                ", ignoreWarnings=" + ignoreWarnings +
                 '}';
     }
 
@@ -37,8 +47,9 @@ public class JobConfigData {
 
         JobConfigData that = (JobConfigData) o;
 
-        if (!projectKey.equals(that.projectKey)) return false;
-        return sonarInstanceName.equals(that.sonarInstanceName);
+        return projectKey.equals(that.projectKey) 
+        	&& sonarInstanceName.equals(that.sonarInstanceName)
+        	&& ignoreWarnings == that.ignoreWarnings;
     }
 
     @Override

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
@@ -20,7 +20,7 @@ public class JobConfigurationService {
     }
 
     public JobConfigData createJobConfigData(JSONObject formData, GlobalConfig globalConfig) {
-        JobConfigData firstInstanceJobConfigData = new JobConfigData();
+    	JobConfigData firstInstanceJobConfigData = new JobConfigData();
         String projectKey = formData.getString("projectKey");
         if(projectKey.startsWith("$"))
         {
@@ -46,8 +46,14 @@ public class JobConfigurationService {
         else {
             name = "";
         }
+        boolean ignoreWarnings = false;
+        if (formData.containsKey("ignoreWarnings")) {
+        	ignoreWarnings = formData.getBoolean("ignoreWarnings");
+        }
+        
         firstInstanceJobConfigData.setProjectKey(projectKey);
         firstInstanceJobConfigData.setSonarInstanceName(name);
+        firstInstanceJobConfigData.setIgnoreWarnings(ignoreWarnings);
         return firstInstanceJobConfigData;
     }
 
@@ -64,6 +70,7 @@ public class JobConfigurationService {
         JobConfigData envVariableJobConfigData = new JobConfigData();
         envVariableJobConfigData.setProjectKey(jobConfigData.getProjectKey());
         envVariableJobConfigData.setSonarInstanceName(jobConfigData.getSonarInstanceName());
+        envVariableJobConfigData.setIgnoreWarnings(jobConfigData.getIgnoreWarnings());
         if(jobConfigData.getProjectKey().isEmpty()) {
             throw new QGException("Empty project key.");
         }

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
@@ -20,7 +20,7 @@ public class JobConfigurationService {
     }
 
     public JobConfigData createJobConfigData(JSONObject formData, GlobalConfig globalConfig) {
-    	JobConfigData firstInstanceJobConfigData = new JobConfigData();
+        JobConfigData firstInstanceJobConfigData = new JobConfigData();
         String projectKey = formData.getString("projectKey");
         if(projectKey.startsWith("$"))
         {

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGBuilder.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGBuilder.java
@@ -3,8 +3,8 @@ package quality.gates.jenkins.plugin;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.Result;
 import hudson.tasks.Builder;
-import jenkins.model.GlobalConfiguration;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class QGBuilder extends Builder {
@@ -53,13 +53,17 @@ public class QGBuilder extends Builder {
         } catch (InterruptedException e) {
             e.printStackTrace(listener.getLogger());
         }
-        boolean buildHasPassed;
         try {
             JobConfigData checkedJobConfigData = jobConfigurationService.checkProjectKeyIfVariable(jobConfigData, build, listener);
-            buildHasPassed = buildDecision.getStatus(globalConfigDataForSonarInstance, checkedJobConfigData);
+            Result buildStatus = buildDecision.getStatus(globalConfigDataForSonarInstance, checkedJobConfigData);
+            boolean buildHasPassed = buildStatus == Result.SUCCESS || buildStatus == Result.UNSTABLE;
             if("".equals(jobConfigData.getSonarInstanceName()))
                 listener.getLogger().println(JobExecutionService.DEFAULT_CONFIGURATION_WARNING);
-            listener.getLogger().println("Build-Step: Quality Gates plugin build passed: " + String.valueOf(buildHasPassed).toUpperCase());
+            listener.getLogger().println("Build-Step: Quality Gates plugin build passed: " 
+                + String.valueOf(buildHasPassed).toUpperCase());
+            if (buildStatus == Result.UNSTABLE) {
+            	build.setResult(Result.UNSTABLE);
+            }
             return buildHasPassed;
         }
         catch (QGException e){

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisher.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisher.java
@@ -55,7 +55,7 @@ public class QGPublisher extends Recorder {
         }
         return true;
     }
-    
+
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
         try {
@@ -65,7 +65,7 @@ public class QGPublisher extends Recorder {
         }
         Result result = build.getResult();
         if (Result.SUCCESS != result) {
-        	listener.getLogger().println("Previous steps failed the build.\nResult is: " + result);
+            listener.getLogger().println("Previous steps failed the build.\nResult is: " + result);
             return false;
         }
         try {

--- a/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/QualityGateResponseParser.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/QualityGateResponseParser.java
@@ -17,8 +17,10 @@ public class QualityGateResponseParser {
 
         String gateStatus = getValueForJSONKey(latestEventResult, "n");
         if (gateStatus.startsWith("Green"))
-            return new QualityGatesStatus("OK");
-        return new QualityGatesStatus("ERROR");
+            return QualityGatesStatus.GREEN;
+        if (gateStatus.startsWith("Orange"))
+        	return QualityGatesStatus.ORANGE;
+        return QualityGatesStatus.RED;
     }
 
     protected JSONObject getLatestEventResult(JSONArray jsonArray) throws QGException {

--- a/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/QualityGatesStatus.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/QualityGatesStatus.java
@@ -1,45 +1,8 @@
 package quality.gates.sonar.api;
 
 
-public class QualityGatesStatus {
-
-    public static final String BUILDS = "OK";
-
-    private String status;
-
-    public QualityGatesStatus(String status) {
-        this.status = status;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public boolean hasStatusGreen(){
-        return BUILDS.equals(status);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()){
-            return false;
-        }
-        QualityGatesStatus that = (QualityGatesStatus) o;
-        return status != null ? status.equals(that.status) : that.status == null;
-    }
-
-    @Override
-    public int hashCode() {
-        return status != null ? status.hashCode() : 0;
-    }
-
-    @Override
-    public String toString() {
-        return "QualityGatesStatus{" +
-                "status='" + status + '\'' +
-                '}';
-    }
+public enum QualityGatesStatus {
+	GREEN,
+	ORANGE,
+	RED;
 }

--- a/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGBuilder/config.jelly
+++ b/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGBuilder/config.jelly
@@ -10,8 +10,8 @@
         }
     </style>
 
-    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 0}">
-        <f:section>
+    <f:section>
+        <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 0}">
             <f:entry>
               <ul class="errorUL">
                     <li>There are no Quality Gates instances configured.</li>
@@ -19,34 +19,19 @@
                     <li>By default http://localhost:9000, Username: admin, Password: admin will be used.</li>
               </ul>
             </f:entry>
-
-            <f:entry field="jobConfigData" description="Enter your project key.">
-                <f:entry title="Project Key" field="projectKey">
-                    <f:textbox name="projectKey" value="${instance.jobConfigData.projectKey}" />
-                </f:entry>
-            </f:entry>
-        </f:section>
-    </j:if>
-    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 1}">
-                <f:section>
-                     <f:entry field="jobConfigData" description="Enter your project key.">
-                          <f:entry title="Project Key" field="projectKey">
-                                <f:textbox name="projectKey" value="${instance.jobConfigData.projectKey}" />
-                          </f:entry>
-                     </f:entry>
-                </f:section>
-    </j:if>
-    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() >= 2}">
-        <f:section>
+        </j:if>
+        <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() >= 2}">
              <f:entry field="listOfGlobalConfigData" title="Sonar instance 'Name'" description="Choose sonar instance">
                  <f:select name="sonarInstancesName" value="${instance.jobConfigData.sonarInstanceName}"/>
              </f:entry>
-
-             <f:entry field="jobConfigData" description="Enter your project key.">
-                  <f:entry title="Project Key" field="projectKey">
-                        <f:textbox name="projectKey" value="${instance.jobConfigData.projectKey}" />
-                  </f:entry>
-             </f:entry>
-        </f:section>
-    </j:if>
+        </j:if>
+        <f:entry field="jobConfigData" description="Enter your project key.">
+            <f:entry title="Project Key" field="projectKey">
+                <f:textbox name="projectKey" value="${instance.jobConfigData.projectKey}" />
+            </f:entry>
+        </f:entry>
+        <f:entry field="ignoreWarnings" title="Ignore Warnings">
+            <f:checkbox name="ignoreWarnings" checked="${instance.jobConfigData.ignoreWarnings}" />
+        </f:entry>
+    </f:section>
 </j:jelly>

--- a/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGBuilder/help-ignoreWarnings.html
+++ b/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGBuilder/help-ignoreWarnings.html
@@ -1,0 +1,5 @@
+<div align="left">
+    <ul style="list-style-type:none">
+        <li>Check this to ignore Sonar results within the warning ranges of a quality gate. This will enable publishing builds with orange status on Sonar. </li>
+    </ul>
+</div>

--- a/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGBuilder/help.html
+++ b/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGBuilder/help.html
@@ -1,6 +1,5 @@
 <div align="left">
     <ul style="list-style-type:none">
         <li>Quality Gates Plugin will fail the build whenever the Quality Gates criteria in the Sonar analysis aren't met</li>
-        <li>(the project Quality Gates status is different than "Passed")</li>
     </ul>
 </div>

--- a/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGPublisher/config.jelly
+++ b/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGPublisher/config.jelly
@@ -10,8 +10,8 @@
         }
     </style>
 
-    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 0}">
-        <f:section>
+    <f:section>
+        <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 0}">
             <f:entry>
               <ul class="errorUL">
                     <li>There are no Quality Gates instances configured.</li>
@@ -19,34 +19,19 @@
                     <li>By default http://localhost:9000, Username: admin, Password: admin will be used.</li>
               </ul>
             </f:entry>
-
-            <f:entry field="jobConfigData" description="Enter your project key.">
-                <f:entry title="Project Key" field="projectKey">
-                    <f:textbox name="projectKey" value="${instance.jobConfigData.projectKey}" />
-                </f:entry>
-            </f:entry>
-        </f:section>
-    </j:if>
-    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() == 1}">
-                <f:section>
-                     <f:entry field="jobConfigData" description="Enter your project key.">
-                          <f:entry title="Project Key" field="projectKey">
-                                <f:textbox name="projectKey" value="${instance.jobConfigData.projectKey}" />
-                          </f:entry>
-                     </f:entry>
-                </f:section>
-    </j:if>
-    <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() >= 2}">
-        <f:section>
+        </j:if>
+        <j:if test="${descriptor.jobExecutionService.getGlobalConfigData().listOfGlobalConfigData.size() >= 2}">
              <f:entry field="listOfGlobalConfigData" title="Sonar instance 'Name'" description="Choose sonar instance">
                  <f:select name="sonarInstancesName" value="${instance.jobConfigData.sonarInstanceName}"/>
              </f:entry>
-
-             <f:entry field="jobConfigData" description="Enter your project key.">
-                  <f:entry title="Project Key" field="projectKey">
-                        <f:textbox name="projectKey" value="${instance.jobConfigData.projectKey}" />
-                  </f:entry>
-             </f:entry>
-        </f:section>
-    </j:if>
+        </j:if>
+        <f:entry field="jobConfigData" description="Enter your project key.">
+            <f:entry title="Project Key" field="projectKey">
+                <f:textbox name="projectKey" value="${instance.jobConfigData.projectKey}" />
+            </f:entry>
+        </f:entry>
+        <f:entry field="ignoreWarnings" title="Ignore Warnings">
+            <f:checkbox name="ignoreWarnings" checked="${instance.jobConfigData.ignoreWarnings}" />
+        </f:entry>
+    </f:section>
 </j:jelly>

--- a/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGPublisher/help-ignoreWarnings.html
+++ b/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGPublisher/help-ignoreWarnings.html
@@ -1,0 +1,5 @@
+<div align="left">
+    <ul style="list-style-type:none">
+        <li>Check this to ignore Sonar results within the warning ranges of a quality gate. This will enable publishing builds with orange status on Sonar. </li>
+    </ul>
+</div>

--- a/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGPublisher/help.html
+++ b/QualityGatesPlugin/src/main/resources/quality/gates/jenkins/plugin/QGPublisher/help.html
@@ -1,6 +1,5 @@
 <div align="left">
     <ul style="list-style-type:none">
         <li>SonarQuality Gates Plugin will fail the build whenever the Quality Gates criteria in the Sonar analysis aren't met</li>
-        <li>(the project Quality Gates status is different than "Passed")</li>
     </ul>
 </div>

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/JobConfigurationServiceTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/JobConfigurationServiceTest.java
@@ -49,7 +49,7 @@ public class JobConfigurationServiceTest {
         formData = new JSONObject();
         formData.put("projectKey", "TestKey");
     }
-
+    
     @Test
     public void testGetListBoxModelShouldReturnOneInstance(){
         createGlobalConfigData();

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/JobConfigurationServiceTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/JobConfigurationServiceTest.java
@@ -49,7 +49,7 @@ public class JobConfigurationServiceTest {
         formData = new JSONObject();
         formData.put("projectKey", "TestKey");
     }
-    
+
     @Test
     public void testGetListBoxModelShouldReturnOneInstance(){
         createGlobalConfigData();

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGBuilderIT.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/QGBuilderIT.java
@@ -72,7 +72,7 @@ public class QGBuilderIT {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
         jobConfigData.setProjectKey("projectKey");
         doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
-        doReturn(true).when(buildDecision).getStatus(any(GlobalConfigDataForSonarInstance.class),any(JobConfigData.class));
+        doReturn(Result.SUCCESS).when(buildDecision).getStatus(any(GlobalConfigDataForSonarInstance.class),any(JobConfigData.class));
         jenkinsRule.buildAndAssertSuccess(freeStyleProject);
         Run lastRun = freeStyleProject._getRuns().newestValue();
         jenkinsRule.assertLogContains("build passed: TRUE", lastRun);
@@ -83,8 +83,31 @@ public class QGBuilderIT {
         setGlobalConfigDataAndJobConfigDataNames("","");
         jobConfigData.setProjectKey("projectKey");
         doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
-        doReturn(true).when(buildDecision).getStatus(any(GlobalConfigDataForSonarInstance.class),any(JobConfigData.class));
+        doReturn(Result.SUCCESS).when(buildDecision).getStatus(any(GlobalConfigDataForSonarInstance.class),any(JobConfigData.class));
         jenkinsRule.buildAndAssertSuccess(freeStyleProject);
+        Run lastRun = freeStyleProject._getRuns().newestValue();
+        jenkinsRule.assertLogContains(JobExecutionService.DEFAULT_CONFIGURATION_WARNING, lastRun);
+        jenkinsRule.assertLogContains("build passed: TRUE", lastRun);
+    }
+
+    @Test
+    public void testPerformShouldSucceedUnstableWithNoWarning() throws Exception {
+        setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
+        jobConfigData.setProjectKey("projectKey");
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
+        doReturn(Result.UNSTABLE).when(buildDecision).getStatus(any(GlobalConfigDataForSonarInstance.class),any(JobConfigData.class));
+        jenkinsRule.assertBuildStatus(Result.UNSTABLE, buildProject(freeStyleProject));
+        Run lastRun = freeStyleProject._getRuns().newestValue();
+        jenkinsRule.assertLogContains("build passed: TRUE", lastRun);
+    }
+
+    @Test
+    public void testPerformShouldSucceedUnstableWithWarning() throws Exception {
+        setGlobalConfigDataAndJobConfigDataNames("","");
+        jobConfigData.setProjectKey("projectKey");
+        doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
+        doReturn(Result.UNSTABLE).when(buildDecision).getStatus(any(GlobalConfigDataForSonarInstance.class),any(JobConfigData.class));
+        jenkinsRule.assertBuildStatus(Result.UNSTABLE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();
         jenkinsRule.assertLogContains(JobExecutionService.DEFAULT_CONFIGURATION_WARNING, lastRun);
         jenkinsRule.assertLogContains("build passed: TRUE", lastRun);
@@ -95,7 +118,7 @@ public class QGBuilderIT {
         setGlobalConfigDataAndJobConfigDataNames(TEST_NAME, TEST_NAME);
         jobConfigData.setProjectKey("projectKey");
         doReturn(globalConfigDataForSonarInstance).when(buildDecision).chooseSonarInstance(globalConfig, jobConfigData);
-        doReturn(false).when(buildDecision).getStatus(any(GlobalConfigDataForSonarInstance.class),any(JobConfigData.class));
+        doReturn(Result.FAILURE).when(buildDecision).getStatus(any(GlobalConfigDataForSonarInstance.class),any(JobConfigData.class));
         jenkinsRule.assertBuildStatus(Result.FAILURE, buildProject(freeStyleProject));
         Run lastRun = freeStyleProject._getRuns().newestValue();
         jenkinsRule.assertLogContains("build passed: FALSE", lastRun);

--- a/QualityGatesPlugin/src/test/java/quality/gates/sonar/api/QualityGateResponseParserTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/sonar/api/QualityGateResponseParserTest.java
@@ -33,18 +33,18 @@ public class QualityGateResponseParserTest {
     @Test
     public void testGetQualityGateResultFromJSONWithOneObjectShouldReturnStatusError() {
         String jsonArray = "[\n{\nid: \"430\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Green)\",\nc: \"Alert\",\ndt: \"2016-03-24T16:28:40+0100\",\nds: \"Major issues variation > 2 over 30 days (2016 Mar 15), Coverage variation < 60 since previous analysis (2016 Mar 24)\"\n}]";
-        assertEquals(new QualityGatesStatus("ERROR"), qualityGateResponseParser.getQualityGateResultFromJSON(jsonArray));
+        assertEquals(QualityGatesStatus.RED, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArray));
     }
 
     @Test
     public void testGetQualityGateResultFromJSONWithMultipleObjectsShouldReturnStatusOK() {
-        assertEquals(new QualityGatesStatus("OK"), qualityGateResponseParser.getQualityGateResultFromJSON(jsonArrayString));
+        assertEquals(QualityGatesStatus.GREEN, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArrayString));
     }
 
     @Test
     public void testGetQualityGateResultFromJSONWithMultipleObjectsShouldReturnStatusError() {
         jsonArrayString = "[\n{\nid: \"455\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Red)\",\nc: \"Alert\",\ndt: \"2016-03-26T12:01:31+0100\",\nds: \"\"\n},\n{\nid: \"455\",\nrk: \"com.opensource:quality-gates\",\nn: \"Green (was Red)\",\nc: \"Alert\",\ndt: \"2016-03-25T12:01:31+0100\",\nds: \"\"\n},\n{\nid: \"430\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Green)\",\nc: \"Alert\",\ndt: \"2016-03-24T16:28:40+0100\",\nds: \"Major issues variation > 2 over 30 days (2016 Mar 15), Coverage variation < 60 since previous analysis (2016 Mar 24)\"\n}]";
-        assertEquals(new QualityGatesStatus("ERROR"), qualityGateResponseParser.getQualityGateResultFromJSON(jsonArrayString));
+        assertEquals(QualityGatesStatus.RED, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArrayString));
     }
 
 

--- a/QualityGatesPlugin/src/test/java/quality/gates/sonar/api/QualityGatesProviderTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/sonar/api/QualityGatesProviderTest.java
@@ -44,7 +44,7 @@ public class QualityGatesProviderTest {
 
     @Test
     public void testGetAPIResultsForQualityGates() throws JSONException {
-        QualityGatesStatus qualityGatesStatus = new QualityGatesStatus("OK");
+        QualityGatesStatus qualityGatesStatus = QualityGatesStatus.GREEN;
         doReturn("").when(globalConfigDataForSonarInstance).getName();
         doReturn("").when(globalConfigDataForSonarInstance).getUsername();
         doReturn("").when(globalConfigDataForSonarInstance).getPass();
@@ -59,11 +59,11 @@ public class QualityGatesProviderTest {
 
     @Test
     public void testGetAPIResultsForQualityGatesNotEqualStatuses() throws JSONException {
-        QualityGatesStatus qualityGatesStatus = new QualityGatesStatus("OK");
+        QualityGatesStatus qualityGatesStatus = QualityGatesStatus.GREEN;
         doReturn("").when(jobConfigData).getProjectKey();
         doReturn("").when(sonarHttpRequester).getAPIInfo(any(JobConfigData.class), any(GlobalConfigDataForSonarInstance.class));
         doReturn(globalConfigDataForSonarInstance).when(sonarInstanceValidationService).validateData(globalConfigDataForSonarInstance);
-        doReturn(new QualityGatesStatus("ERROR")).when(qualityGateResponseParser).getQualityGateResultFromJSON(anyString());
+        doReturn(QualityGatesStatus.RED).when(qualityGateResponseParser).getQualityGateResultFromJSON(anyString());
 
         assertNotEquals(qualityGatesStatus, qualityGatesProvider.getAPIResultsForQualityGates(jobConfigData, globalConfigDataForSonarInstance));
     }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # quality-gates-plugin
-Jenkins plugin that fails the build if the predefined sonar quality gates are not green.
+Jenkins plugin that fails the build if SonarQube quality gates are not green.
+It is also possible to allow builds to be marked unstable for projects where the 
+quality gate returned by a Sonar server is orange.
 
 You can find the documentation on the next link:
 https://wiki.jenkins-ci.org/display/JENKINS/Quality+Gates+Plugin


### PR DESCRIPTION
Hi,

Here where I work we started using this plugin but we required it to allow Jenkins to continue builds/deploys if the status of the project analysis on Sonar is orange, which works as a warning zone without blocking the build (but marking the build as unstable just like JUnit test not passing). I've made the required changes to that but entirely optional to be set by build project. Also I think I've written/adapted enough tests to verify the implementation is correct and maintains the previous behaviour. This code is already running as expected on our production server and we'd like to share our solution back to the community.

Regards,
Leonardo
