### PR TITLE
Add support for expanding variables in project key

### DIFF
--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/JobConfigurationServiceTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/JobConfigurationServiceTest.java
@@ -49,8 +49,6 @@ public class JobConfigurationServiceTest {
         jobConfigurationService = new JobConfigurationService();
         formData = new JSONObject();
         formData.put("projectKey", "TestKey");
-
-        doReturn(mock(PrintStream.class)).when(listener).getLogger();
     }
 
     @Test
@@ -132,7 +130,7 @@ public class JobConfigurationServiceTest {
 
     @Test
     public void testIfProjectKeyStartsWithDolarSignAndVarIsFound() throws Exception {
-        String key = "${PROJECT_KEY}";
+        String key = "$PROJECT_KEY";
         doReturn(key).when(jobConfigData).getProjectKey();
         EnvVars envVars = mock(EnvVars.class);
         doReturn(envVars).when(build).getEnvironment(listener);

--- a/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/JobConfigurationServiceTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/jenkins/plugin/JobConfigurationServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,6 +49,8 @@ public class JobConfigurationServiceTest {
         jobConfigurationService = new JobConfigurationService();
         formData = new JSONObject();
         formData.put("projectKey", "TestKey");
+
+        doReturn(mock(PrintStream.class)).when(listener).getLogger();
     }
 
     @Test
@@ -129,11 +132,11 @@ public class JobConfigurationServiceTest {
 
     @Test
     public void testIfProjectKeyStartsWithDolarSignAndVarIsFound() throws Exception {
-        String key = "$";
+        String key = "${PROJECT_KEY}";
         doReturn(key).when(jobConfigData).getProjectKey();
         EnvVars envVars = mock(EnvVars.class);
         doReturn(envVars).when(build).getEnvironment(listener);
-        doReturn("EnvVariable").when(envVars).get(anyString());
+        doReturn("EnvVariable").when(envVars).get("PROJECT_KEY");
         JobConfigData returnedData = jobConfigurationService.checkProjectKeyIfVariable(jobConfigData, build, listener);
         assertTrue(returnedData.getProjectKey().equals("EnvVariable"));
     }
@@ -155,11 +158,11 @@ public class JobConfigurationServiceTest {
 
     @Test
     public void testIfProjectKeyStartsWithDolarSignAndHasBracketsVarIsFound() throws Exception {
-        String key = "${}";
+        String key = "${PROJECT_KEY}";
         doReturn(key).when(jobConfigData).getProjectKey();
         EnvVars envVars = mock(EnvVars.class);
         doReturn(envVars).when(build).getEnvironment(listener);
-        doReturn("EnvVariable").when(envVars).get(anyString());
+        doReturn("EnvVariable").when(envVars).get("PROJECT_KEY");
         JobConfigData returnedData = jobConfigurationService.checkProjectKeyIfVariable(jobConfigData, build, listener);
         assertTrue(returnedData.getProjectKey().equals("EnvVariable"));
     }


### PR DESCRIPTION
I have extended support for expanding variables in project key field. Now build and environment variables are supported at any plaсe in string.