### PR TITLE
Resolve Runtime Env Variable

### DIFF
--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
@@ -14,8 +14,8 @@ import net.sf.json.JSONObject;
 
 public class JobConfigurationService {
 
-    public static final Pattern ENV_VARIABLE_WITH_BRACES_PATTERN = Pattern.compile( "(\\$\\{[a-zA-Z_]+\\})" );
-    public static final Pattern ENV_VARIABLE_WITHOUT_BRACES_PATTERN = Pattern.compile( "(\\$[a-zA-Z_]+)" );
+    private static final Pattern ENV_VARIABLE_WITH_BRACES_PATTERN = Pattern.compile( "(\\$\\{[a-zA-Z_]+\\})" );
+    private static final Pattern ENV_VARIABLE_WITHOUT_BRACES_PATTERN = Pattern.compile( "(\\$[a-zA-Z_]+)" );
     
     public ListBoxModel getListOfSonarInstanceNames(GlobalConfig globalConfig) {
         ListBoxModel listBoxModel = new ListBoxModel();

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
@@ -1,18 +1,22 @@
 package quality.gates.jenkins.plugin;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import hudson.EnvVars;
-import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-
 public class JobConfigurationService {
 
+    public static final Pattern ENV_VARIABLE_WITH_BRACES_PATTERN = Pattern.compile( "(\\$\\{[a-zA-Z_]+\\})" );
+    public static final Pattern ENV_VARIABLE_WITHOUT_BRACES_PATTERN = Pattern.compile( "(\\$[a-zA-Z_]+)" );
+    
     public ListBoxModel getListOfSonarInstanceNames(GlobalConfig globalConfig) {
         ListBoxModel listBoxModel = new ListBoxModel();
         for (GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance : globalConfig.fetchListOfGlobalConfigData()) {
@@ -24,16 +28,9 @@ public class JobConfigurationService {
     public JobConfigData createJobConfigData(JSONObject formData, GlobalConfig globalConfig) {
         JobConfigData firstInstanceJobConfigData = new JobConfigData();
         String projectKey = formData.getString("projectKey");
-        if(projectKey.startsWith("$"))
+        
+        if(!projectKey.startsWith("$"))
         {
-            String systemVariableName = projectKey;
-            String getEnvVariable = systemVariableName.substring(2, systemVariableName.length()-1);
-            projectKey = System.getenv(getEnvVariable);
-            if(projectKey == null) {
-                throw new QGException("Environment variable with name '" + getEnvVariable + "' does not exist.");
-            }
-        }
-        else {
             try {
                 projectKey = URLDecoder.decode(projectKey, "UTF-8");
             } catch (UnsupportedEncodingException e) {
@@ -64,23 +61,66 @@ public class JobConfigurationService {
 
     public JobConfigData checkProjectKeyIfVariable(JobConfigData jobConfigData, AbstractBuild build, BuildListener listener) throws QGException {
         String projectKey = jobConfigData.getProjectKey();
-        if(projectKey.isEmpty()) {
+        
+        if(projectKey.isEmpty()) 
+        {
             throw new QGException("Empty project key.");
         }
 
-        projectKey = Util.replaceMacro(projectKey, build.getBuildVariables());
+        final JobConfigData envVariableJobConfigData = new JobConfigData();
+        envVariableJobConfigData.setSonarInstanceName(jobConfigData.getSonarInstanceName());
+
+        
         try {
-            EnvVars env = build.getEnvironment(listener);
-            projectKey = Util.replaceMacro(projectKey, env);
-        } catch (IOException e) {
+            envVariableJobConfigData.setProjectKey(getProjectKey(projectKey, build.getEnvironment(listener)));
+        } 
+        catch (IOException e) 
+        {
             throw new QGException(e);
-        } catch (InterruptedException e) {
+        } 
+        catch (InterruptedException e) 
+        {
             throw new QGException(e);
         }
 
-        JobConfigData envVariableJobConfigData = new JobConfigData();
-        envVariableJobConfigData.setProjectKey(projectKey);
         envVariableJobConfigData.setSonarInstanceName(jobConfigData.getSonarInstanceName());
         return envVariableJobConfigData;
+    }
+    
+    private String getProjectKey(final String projectKey, EnvVars env) 
+    {
+        final String projectKeyAfterFirstResolving = resolveEmbeddedEnvVariables(projectKey, env, ENV_VARIABLE_WITH_BRACES_PATTERN, 1);
+
+        return resolveEmbeddedEnvVariables(projectKeyAfterFirstResolving, env, ENV_VARIABLE_WITHOUT_BRACES_PATTERN, 0);
+    }
+    
+    private String resolveEmbeddedEnvVariables(final String projectKey, final EnvVars env, final Pattern pattern, final int braceOffset) 
+    {
+        final Matcher matcher = pattern.matcher(projectKey);
+        final StringBuilder builder = new StringBuilder(projectKey);
+        boolean matchesFound = false;
+        int offset = 0;
+
+        while(matcher.find()) 
+        {
+            final String envVariable = projectKey.substring(matcher.start() + braceOffset + 1, matcher.end() - braceOffset);
+            final String envValue = env.get(envVariable);
+
+            if(envValue == null) 
+            {
+                throw new QGException("Environment Variable [" + envVariable + "] not found");
+            }
+
+            builder.replace(matcher.start() + offset, matcher.end() + offset, envValue);
+            offset += envValue.length() - matcher.group(1).length();
+            matchesFound = true;
+        }
+
+        if(matchesFound) 
+        {
+            return getProjectKey(builder.toString(), env);
+        }
+
+        return builder.toString();
     }
 }


### PR DESCRIPTION
The current version only handles "static" environment variables. This means we can't build dynamic project key by concat group id and artifact id from pom.xml:

> quality.gates.jenkins.plugin.QGException: Environment variable with name 'POM_GROUPID}:${POM_ARTIFACTID' does not exist.

![2017-01-10 15_34_22-test_sonar_mvn config jenkins](https://cloud.githubusercontent.com/assets/13882589/21809999/5a5dca1e-d74a-11e6-9fa1-29d3d7bf0f23.png)

