### PR TITLE
[FIXED JENKINS-39411] Make BuildDecision field transient to avoid RuntimeException.

### DIFF
--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisher.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisher.java
@@ -9,7 +9,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class QGPublisher extends Recorder {
 
     private JobConfigData jobConfigData;
-    private transient BuildDecision buildDecision;
+    private BuildDecision buildDecision;
     private JobConfigurationService jobConfigurationService;
     private JobExecutionService jobExecutionService;
     private GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisher.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/QGPublisher.java
@@ -9,7 +9,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class QGPublisher extends Recorder {
 
     private JobConfigData jobConfigData;
-    private BuildDecision buildDecision;
+    private transient BuildDecision buildDecision;
     private JobConfigurationService jobConfigurationService;
     private JobExecutionService jobExecutionService;
     private GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance;

--- a/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/SonarHttpRequester.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/SonarHttpRequester.java
@@ -25,7 +25,7 @@ public class SonarHttpRequester {
 
     private static final String SONAR_API_GATE = "/api/events?resource=%s&format=json&categories=Alert";
 
-    private HttpClientContext context;
+    private transient HttpClientContext context;
 
     public SonarHttpRequester() {
     }


### PR DESCRIPTION
Hotfix to avoid RuntimeException during reconfiguration of jobs.

See: JENKINS-39411