### PR TITLE
Environment variables expansion fails if variable name contains dot/dash

### DIFF
--- a/QualityGatesPlugin/pom.xml
+++ b/QualityGatesPlugin/pom.xml
@@ -34,7 +34,7 @@
     <artifactId>quality-gates</artifactId>
     <name>Quality Gates Plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Quality+Gates+Plugin</url>
-    <version>2.7-SNAPSHOT</version>
+    <version>2.7.2</version>
     <description>Fails the build whenever the Quality Gates criteria in the Sonar analysis aren't met (the project Quality Gates status is different than "Passed")</description>
     <packaging>hpi</packaging>
 

--- a/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/jenkins/plugin/JobConfigurationService.java
@@ -14,8 +14,8 @@ import java.util.regex.Pattern;
 
 public class JobConfigurationService {
 
-    private static final Pattern ENV_VARIABLE_WITH_BRACES_PATTERN = Pattern.compile( "(\\$\\{[a-zA-Z_]+\\})" );
-    private static final Pattern ENV_VARIABLE_WITHOUT_BRACES_PATTERN = Pattern.compile( "(\\$[a-zA-Z_]+)" );
+    private static final Pattern ENV_VARIABLE_WITH_BRACES_PATTERN = Pattern.compile( "(\\$\\{[a-zA-Z_]+[a-zA-Z0-9_\\.-]*\\})" );
+    private static final Pattern ENV_VARIABLE_WITHOUT_BRACES_PATTERN = Pattern.compile( "(\\$[a-zA-Z_]+[a-zA-Z0-9_\\.-]*)" );
 
     public ListBoxModel getListOfSonarInstanceNames(GlobalConfig globalConfig) {
         ListBoxModel listBoxModel = new ListBoxModel();

--- a/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/QualityGatesProvider.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/QualityGatesProvider.java
@@ -26,11 +26,24 @@ public class QualityGatesProvider {
 
     public QualityGatesStatus getAPIResultsForQualityGates(JobConfigData jobConfigData, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) throws JSONException {
         GlobalConfigDataForSonarInstance validatedData = sonarInstanceValidationService.validateData(globalConfigDataForSonarInstance);
-        String requesterResult = getRequesterResult(jobConfigData, validatedData);
-        return qualityGateResponseParser.getQualityGateResultFromJSON(requesterResult);
+        
+        Float sonarVersion = sonarHttpRequester.getSonarQubeVersion(globalConfigDataForSonarInstance);
+
+        boolean useNewAPI = false;
+        if(sonarVersion >= 6.3) {
+        	useNewAPI = true;
+        }
+        
+        String requesterResult = getRequesterResult(jobConfigData, validatedData, useNewAPI);
+        return qualityGateResponseParser.getQualityGateResultFromJSON(requesterResult, useNewAPI);
     }
 
-    public String getRequesterResult(JobConfigData jobConfigData, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) throws QGException {
-        return sonarHttpRequester.getAPIInfo(jobConfigData, globalConfigDataForSonarInstance);
+    public String getRequesterResult(JobConfigData jobConfigData, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance, boolean useNewAPI) throws QGException {
+        
+    	if(useNewAPI) {
+    		return sonarHttpRequester.getAPIInfoNew(jobConfigData, globalConfigDataForSonarInstance);
+    	} else {
+    		return sonarHttpRequester.getAPIInfo(jobConfigData, globalConfigDataForSonarInstance);
+    	}
     }
 }

--- a/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/SonarHttpRequester.java
+++ b/QualityGatesPlugin/src/main/java/quality/gates/sonar/api/SonarHttpRequester.java
@@ -23,18 +23,43 @@ import java.util.List;
 
 public class SonarHttpRequester {
 
+	private static final String SONAR_API_VERSION = "/api/server/version";
     private static final String SONAR_API_GATE = "/api/events?resource=%s&format=json&categories=Alert";
+    private static final String SONAR_API_GATE_NEW = "/api/project_analyses/search?project=%s&category=QUALITY_GATE";
 
     private transient HttpClientContext context;
 
     public SonarHttpRequester() {
     }
 
-    public String getAPIInfo(JobConfigData projectKey, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) throws QGException {
-        String sonarApiGate = globalConfigDataForSonarInstance.getSonarUrl() + String.format(SONAR_API_GATE, projectKey.getProjectKey());
-
-        context = HttpClientContext.create();
+    public Float getSonarQubeVersion(GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) throws QGException {
+    	String sonarVersionAPI = globalConfigDataForSonarInstance.getSonarUrl() + SONAR_API_VERSION;
+    	
+    	context = HttpClientContext.create();
         CloseableHttpClient client = HttpClientBuilder.create().build();
+    	
+    	HttpGet request = new HttpGet(sonarVersionAPI);
+    	String result = executeGetRequest(client, request);
+    	String[] resultTab = result.split("\\.");
+    	if(resultTab.length >= 2) {
+    		try {
+    			int majorVersion = Integer.parseInt(resultTab[0]);
+    			int minorVersion = Integer.parseInt(resultTab[1]);
+    			
+    			return Float.parseFloat(majorVersion+"."+minorVersion);
+    			
+    		} catch (NumberFormatException e) {
+    			throw new QGException("Can't parse SonarQube version : "+result);
+    		}
+    	} else {
+    		throw new QGException("Can't find major version of SonarQube : "+result);
+    	}
+    }
+    
+    private String getApiInfo(JobConfigData projectKey, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance, String sonarApiGate) throws QGException {
+    	context = HttpClientContext.create();
+        CloseableHttpClient client = HttpClientBuilder.create().build();
+             
         HttpPost loginHttpPost = new HttpPost(globalConfigDataForSonarInstance.getSonarUrl() + "/sessions/login");
         List<NameValuePair> nvps = new ArrayList<>();
         nvps.add(new BasicNameValuePair("login", globalConfigDataForSonarInstance.getUsername()));
@@ -45,6 +70,18 @@ public class SonarHttpRequester {
         executePostRequest(client, loginHttpPost);
         HttpGet request = new HttpGet(String.format(sonarApiGate, projectKey.getProjectKey()));
         return executeGetRequest(client, request);
+    }
+    
+    public String getAPIInfo(JobConfigData projectKey, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) throws QGException {
+        String sonarApiGate = globalConfigDataForSonarInstance.getSonarUrl() + String.format(SONAR_API_GATE, projectKey.getProjectKey());
+        
+        return getApiInfo(projectKey, globalConfigDataForSonarInstance, sonarApiGate);
+    }
+    
+    public String getAPIInfoNew(JobConfigData projectKey, GlobalConfigDataForSonarInstance globalConfigDataForSonarInstance) throws QGException {
+    	String sonarApiGate = globalConfigDataForSonarInstance.getSonarUrl() + String.format(SONAR_API_GATE_NEW, projectKey.getProjectKey());
+    	
+    	return getApiInfo(projectKey, globalConfigDataForSonarInstance, sonarApiGate);
     }
 
     private String executeGetRequest(CloseableHttpClient client, HttpGet request) throws QGException {

--- a/QualityGatesPlugin/src/test/java/quality/gates/sonar/api/QualityGateResponseParserTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/sonar/api/QualityGateResponseParserTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import quality.gates.jenkins.plugin.QGException;
 
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -22,52 +24,98 @@ public class QualityGateResponseParserTest {
     private QualityGateResponseParser qualityGateResponseParser;
 
     private String jsonArrayString;
+    private String jsonObjectString;
 
     @Before
     public void init() {
         qualityGateResponseParser = new QualityGateResponseParser();
         jsonArrayString = "[\n{\nid: \"455\",\nrk: \"com.opensource:quality-gates\",\nn: \"Green (was Red)\",\nc: \"Alert\",\ndt: \"2016-03-25T12:01:31+0100\",\nds: \"\"\n},\n{\nid: \"430\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Green)\",\nc: \"Alert\",\ndt: \"2016-03-24T16:28:40+0100\",\nds: \"Major issues variation > 2 over 30 days (2016 Mar 15), Coverage variation < 60 since previous analysis (2016 Mar 24)\"\n}]";
+        jsonObjectString = "{paging:{pageIndex:1,pageSize:100,total:2},analyses:[{key:\"AWDWWzYlMRo0rJ7-ewqe\",date:\"2018-01-08T15:19:33+0000\",events:[{key:\"AWDWW0VGMRo0rJ7-ewqf\",category:\"QUALITY_GATE\",name:\"Green (was Orange)\",description:\"Vulnerabilities > 2\"},{key:\"AWDWW0VMMRo0rJ7-ewqg\",category:\"VERSION\",name:\"1.0.0-SNAPSHOT\"}]},{key:\"AWDVgjN8MRo0rJ7-ewmz\",date:\"2018-01-08T11:22:20+0000\",events:[{key:\"AWDVgkzGMRo0rJ7-ewqZ\",category:\"QUALITY_GATE\",name:\"Orange\",description:\"Vulnerabilities > 2\"}]}]}";
     }
 
 
     @Test
-    public void testGetQualityGateResultFromJSONWithOneObjectShouldReturnStatusError() {
-        String jsonArray = "[\n{\nid: \"430\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Green)\",\nc: \"Alert\",\ndt: \"2016-03-24T16:28:40+0100\",\nds: \"Major issues variation > 2 over 30 days (2016 Mar 15), Coverage variation < 60 since previous analysis (2016 Mar 24)\"\n}]";
-        assertEquals(QualityGatesStatus.RED, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArray));
+    public void testGetQualityGateResultFromJSONWithOneObjectShouldReturnStatusErrorNewAPI() {
+        String jsonObject = "{paging:{pageIndex:1,pageSize:100,total:2},analyses:[{key:\"AWDWWzYlMRo0rJ7-ewqe\",date:\"2018-01-08T15:19:33+0000\",events:[{key:\"AWDWW0VGMRo0rJ7-ewqf\",category:\"QUALITY_GATE\",name:\"Red (was Orange)\",description:\"Vulnerabilities > 2\"},{key:\"AWDWW0VMMRo0rJ7-ewqg\",category:\"VERSION\",name:\"1.0.0-SNAPSHOT\"}]},{key:\"AWDVgjN8MRo0rJ7-ewmz\",date:\"2018-01-08T11:22:20+0000\",events:[{key:\"AWDVgkzGMRo0rJ7-ewqZ\",category:\"QUALITY_GATE\",name:\"Orange\",description:\"Vulnerabilities > 2\"}]}]}";
+        assertEquals(QualityGatesStatus.RED, qualityGateResponseParser.getQualityGateResultFromJSON(jsonObject, true));
+    }
+    
+    @Test
+    public void testGetQualityGateResultFromJSONWithOneObjectShouldReturnStatusErrorOldAPI() {
+        String jsonArray = "[\n{\nid: \"455\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Orange)\",\nc: \"Alert\",\ndt: \"2016-03-25T12:01:31+0100\",\nds: \"\"\n},\n{\nid: \"430\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Green)\",\nc: \"Alert\",\ndt: \"2016-03-24T16:28:40+0100\",\nds: \"Major issues variation > 2 over 30 days (2016 Mar 15), Coverage variation < 60 since previous analysis (2016 Mar 24)\"\n}]";
+        assertEquals(QualityGatesStatus.RED, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArray, false));
     }
 
     @Test
-    public void testGetQualityGateResultFromJSONWithMultipleObjectsShouldReturnStatusOK() {
-        assertEquals(QualityGatesStatus.GREEN, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArrayString));
+    public void testGetQualityGateResultFromJSONWithMultipleObjectsShouldReturnStatusOKNewAPI() {
+        assertEquals(QualityGatesStatus.GREEN, qualityGateResponseParser.getQualityGateResultFromJSON(jsonObjectString, true));
+    }
+    
+    @Test
+    public void testGetQualityGateResultFromJSONWithMultipleObjectsShouldReturnStatusOKOldAPI() {
+        assertEquals(QualityGatesStatus.GREEN, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArrayString, false));
     }
 
     @Test
-    public void testGetQualityGateResultFromJSONWithMultipleObjectsShouldReturnStatusError() {
-        jsonArrayString = "[\n{\nid: \"455\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Red)\",\nc: \"Alert\",\ndt: \"2016-03-26T12:01:31+0100\",\nds: \"\"\n},\n{\nid: \"455\",\nrk: \"com.opensource:quality-gates\",\nn: \"Green (was Red)\",\nc: \"Alert\",\ndt: \"2016-03-25T12:01:31+0100\",\nds: \"\"\n},\n{\nid: \"430\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Green)\",\nc: \"Alert\",\ndt: \"2016-03-24T16:28:40+0100\",\nds: \"Major issues variation > 2 over 30 days (2016 Mar 15), Coverage variation < 60 since previous analysis (2016 Mar 24)\"\n}]";
-        assertEquals(QualityGatesStatus.RED, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArrayString));
+    public void testGetQualityGateResultFromJSONWithMultipleObjectsShouldReturnStatusErrorNewAPI() {
+        jsonObjectString = "{paging:{pageIndex:1,pageSize:100,total:2},analyses:[{key:\"AWDWWzYlMRo0rJ7-ewqe\",date:\"2018-01-08T15:19:33+0000\",events:[{key:\"AWDWW0VGMRo0rJ7-ewqf\",category:\"QUALITY_GATE\",name:\"Red (was Orange)\",description:\"Vulnerabilities > 2\"},{key:\"AWDWW0VMMRo0rJ7-ewqg\",category:\"VERSION\",name:\"1.0.0-SNAPSHOT\"}]},{key:\"AWDVgjN8MRo0rJ7-ewmz\",date:\"2018-01-08T11:22:20+0000\",events:[{key:\"AWDVgkzGMRo0rJ7-ewqZ\",category:\"QUALITY_GATE\",name:\"Orange\",description:\"Vulnerabilities > 2\"}]}]}";
+        assertEquals(QualityGatesStatus.RED, qualityGateResponseParser.getQualityGateResultFromJSON(jsonObjectString, true));
+    }
+    
+    @Test
+    public void testGetQualityGateResultFromJSONWithMultipleObjectsShouldReturnStatusErrorOldAPI() {
+        jsonArrayString = "[\n{\nid: \"455\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Orange)\",\nc: \"Alert\",\ndt: \"2016-03-25T12:01:31+0100\",\nds: \"\"\n},\n{\nid: \"430\",\nrk: \"com.opensource:quality-gates\",\nn: \"Red (was Green)\",\nc: \"Alert\",\ndt: \"2016-03-24T16:28:40+0100\",\nds: \"Major issues variation > 2 over 30 days (2016 Mar 15), Coverage variation < 60 since previous analysis (2016 Mar 24)\"\n}]";
+        assertEquals(QualityGatesStatus.RED, qualityGateResponseParser.getQualityGateResultFromJSON(jsonArrayString, false));
     }
 
 
     @Test
     public void testGetLatestEventResultWhenFirstObjectIsntWithLatestDate() throws JSONException {
-        JSONArray array = new JSONArray();
-        JSONObject firstJsonObject = new JSONObject();
-        firstJsonObject.put("id", "455");
-        firstJsonObject.put("rk", COM_OPENSOURCE_QUALITY_GATES);
-        firstJsonObject.put("n", GREEN_WAS_RED);
-        firstJsonObject.put("c", ALERT);
-        firstJsonObject.put(DT, T12_01_31_0100);
-        firstJsonObject.put("ds", "");
-        JSONObject secondJsonObject = new JSONObject();
-        secondJsonObject.put("id", "456");
-        secondJsonObject.put("rk", COM_OPENSOURCE_QUALITY_GATES);
-        secondJsonObject.put("n", GREEN_WAS_RED);
-        secondJsonObject.put("c", ALERT);
-        secondJsonObject.put(DT,  "2016-03-26T12:01:31+0100");
-        secondJsonObject.put("ds", "");
-        array.put(firstJsonObject);
-        array.put(secondJsonObject);
-        assertEquals(secondJsonObject.toString(), qualityGateResponseParser.getLatestEventResult(array).toString());
+        
+        JSONObject jsonObject = new JSONObject();
+        
+        JSONObject paging = new JSONObject();
+        paging.put("pageIndex", 1);
+        paging.put("pageSize", 100);
+        paging.put("total", 2);
+        
+        JSONArray analyses = new JSONArray();
+        
+        JSONObject analysis1 = new JSONObject();
+        analysis1.put("key", "AWDWWzYlMRo0rJ7-ewqe");
+        analysis1.put("date", "2018-01-08T15:19:33+0000");
+        JSONArray events1 = new JSONArray();
+        JSONObject ev1 = new JSONObject();
+        ev1.put("key", "AWDWW0VGMRo0rJ7-ewqf");
+        ev1.put("category", "QUALITY_GATE");
+        ev1.put("name", "Red");
+        ev1.put("description", "Vulnerabilities > 2");
+        events1.put(ev1);
+        JSONObject ev2 = new JSONObject();
+        ev2.put("key", "AWDWW0VMMRo0rJ7-ewqg");
+        ev2.put("category", "VERSION");
+        ev2.put("name", "1.0.0-SNAPSHOT");
+        events1.put(ev2);
+        analysis1.put("events", events1);
+        analyses.put(analysis1);
+        
+        JSONObject analysis2 = new JSONObject();
+        analysis2.put("key", "AWDWWzYlMRo0rJ7-ewqe");
+        analysis2.put("date", "2018-01-08T11:22:20+0000");
+        JSONArray events2 = new JSONArray();
+        JSONObject ev3 = new JSONObject();
+        ev3.put("key", "AWDVgkzGMRo0rJ7-ewqZ");
+        ev3.put("category", "QUALITY_GATE");
+        ev3.put("name", "Orange");
+        ev3.put("description", "Vulnerabilities > 2");
+        events2.put(ev3);
+        analysis2.put("events", events2);
+        analyses.put(analysis2);
+        
+        jsonObject.put("paging", paging);
+        jsonObject.put("analyses", analyses);
+        
+        assertEquals(ev1.toString(), qualityGateResponseParser.getLastestEventResultNewAPI(jsonObject).toString());
     }
 
     @Test
@@ -154,6 +202,28 @@ public class QualityGateResponseParserTest {
         String expected = T12_01_31_0100;
         String actual = qualityGateResponseParser.getValueForJSONKey(jsonObject, "dateeee");
         assertEquals(expected, actual);
+    }
+    
+    @Test
+    public void testFromISO8601UTC() {
+    	String date = "2018-01-08T15:19:33+0100";
+    	Date result = qualityGateResponseParser.fromISO8601UTC(date);
+    	Calendar cal = Calendar.getInstance();
+    	
+    	cal.setTime(result);
+    	
+    	assertEquals(2018,  cal.get(Calendar.YEAR));
+    	assertEquals(0, cal.get(Calendar.MONTH));
+    	assertEquals(8, cal.get(Calendar.DAY_OF_MONTH));
+    	assertEquals(15, cal.get(Calendar.HOUR_OF_DAY));
+    	assertEquals(19, cal.get(Calendar.MINUTE));
+    }
+    
+    @Test(expected = QGException.class)
+    public void testFromISO8601UTCInvalidFormat() {
+    	String invalidDate = "2018/01/08";
+    	qualityGateResponseParser.fromISO8601UTC(invalidDate);
+    	
     }
 
 }

--- a/QualityGatesPlugin/src/test/java/quality/gates/sonar/api/QualityGatesProviderTest.java
+++ b/QualityGatesPlugin/src/test/java/quality/gates/sonar/api/QualityGatesProviderTest.java
@@ -43,7 +43,7 @@ public class QualityGatesProviderTest {
     }
 
     @Test
-    public void testGetAPIResultsForQualityGates() throws JSONException {
+    public void testGetAPIResultsForQualityGatesNewAPI() throws JSONException {
         QualityGatesStatus qualityGatesStatus = QualityGatesStatus.GREEN;
         doReturn("").when(globalConfigDataForSonarInstance).getName();
         doReturn("").when(globalConfigDataForSonarInstance).getUsername();
@@ -52,7 +52,22 @@ public class QualityGatesProviderTest {
         doReturn("").when(jobConfigData).getProjectKey();
         doReturn("").when(sonarHttpRequester).getAPIInfo(any(JobConfigData.class), any(GlobalConfigDataForSonarInstance.class));
         doReturn(globalConfigDataForSonarInstance).when(sonarInstanceValidationService).validateData(globalConfigDataForSonarInstance);
-        doReturn(qualityGatesStatus).when(qualityGateResponseParser).getQualityGateResultFromJSON(anyString());
+        doReturn(qualityGatesStatus).when(qualityGateResponseParser).getQualityGateResultFromJSON(anyString(), Boolean.valueOf(anyString()));
+
+        assertEquals(qualityGatesStatus, qualityGatesProvider.getAPIResultsForQualityGates(jobConfigData, globalConfigDataForSonarInstance));
+    }
+    
+    @Test
+    public void testGetAPIResultsForQualityGatesOldAPI() throws JSONException {
+        QualityGatesStatus qualityGatesStatus = QualityGatesStatus.GREEN;
+        doReturn("").when(globalConfigDataForSonarInstance).getName();
+        doReturn("").when(globalConfigDataForSonarInstance).getUsername();
+        doReturn("").when(globalConfigDataForSonarInstance).getPass();
+        doReturn("").when(globalConfigDataForSonarInstance).getSonarUrl();
+        doReturn("").when(jobConfigData).getProjectKey();
+        doReturn("").when(sonarHttpRequester).getAPIInfo(any(JobConfigData.class), any(GlobalConfigDataForSonarInstance.class));
+        doReturn(globalConfigDataForSonarInstance).when(sonarInstanceValidationService).validateData(globalConfigDataForSonarInstance);
+        doReturn(qualityGatesStatus).when(qualityGateResponseParser).getQualityGateResultFromJSON(anyString(), Boolean.valueOf(anyString()));
 
         assertEquals(qualityGatesStatus, qualityGatesProvider.getAPIResultsForQualityGates(jobConfigData, globalConfigDataForSonarInstance));
     }
@@ -63,7 +78,7 @@ public class QualityGatesProviderTest {
         doReturn("").when(jobConfigData).getProjectKey();
         doReturn("").when(sonarHttpRequester).getAPIInfo(any(JobConfigData.class), any(GlobalConfigDataForSonarInstance.class));
         doReturn(globalConfigDataForSonarInstance).when(sonarInstanceValidationService).validateData(globalConfigDataForSonarInstance);
-        doReturn(QualityGatesStatus.RED).when(qualityGateResponseParser).getQualityGateResultFromJSON(anyString());
+        doReturn(QualityGatesStatus.RED).when(qualityGateResponseParser).getQualityGateResultFromJSON(anyString(), Boolean.valueOf(anyString()));
 
         assertNotEquals(qualityGatesStatus, qualityGatesProvider.getAPIResultsForQualityGates(jobConfigData, globalConfigDataForSonarInstance));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>quality-gates-main</artifactId>
   <name>Quality Gates Plugin Main</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Quality+Gates+Plugin</url>
-  <version>2.7-SNAPSHOT</version>
+  <version>2.7.2-SNAPSHOT</version>
   <description>Fails the build whenever the Quality Gates criteria in the Sonar analysis aren't met (the project Quality Gates status is different than "Passed")</description>
   <packaging>pom</packaging>
   

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>quality-gates-main</artifactId>
   <name>Quality Gates Plugin Main</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Quality+Gates+Plugin</url>
-  <version>2.7.2-SNAPSHOT</version>
+  <version>2.7.2</version>
   <description>Fails the build whenever the Quality Gates criteria in the Sonar analysis aren't met (the project Quality Gates status is different than "Passed")</description>
   <packaging>pom</packaging>
   


### PR DESCRIPTION
For version 2.5, environment variable names can contain dot or dashes. Project keys like $sonar.projectkey in Jenkins configuration are quite common.

New changes broke existing configuration if job is configured with project keys like $sonar.projectkey. Getting below error during build 
"java.net.URISyntaxException: Illegal character in query at index 62: https://foo.com/api/events?resource=${sonar.projectKey}&format=json&categories=Alert "

Per [Open Group](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html) , pretty much any character is allowed for environment variable name except equals. However we need to consider compatibility with all utilities as well.

This PR address issue with dot and/or dash characters in environment variable names.


